### PR TITLE
refactor: convert api endpoints to feature driven schemas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,14 +30,15 @@ To add a new feature: extend `VismaModule`, implement `injectables()`, and regis
 
 ### API Layer (`src/api/`)
 
+Validation is **feature-driven**: the API is undocumented and unstable, so each module validates only the fields it actually consumes, instead of endpoints enforcing whole-response schemas.
+
 - **`ApiClient`** — thin fetch wrapper; always sends `credentials: 'include'` to reuse the user's existing browser session. Authentication is handled entirely by the browser — the userscript never manages tokens or login flows.
 - **`Session`** — facade that lazily initialises all endpoints and caches the learner ID. Inject `Session` into modules rather than constructing endpoints directly.
-- **Endpoints** (`src/api/endpoints/`) — one class per resource (User, Timetable, Calendar, Attendance, School, Assessment, Inbox, Events).
-- **Types** (`src/api/types/`) — Zod schemas for every endpoint response. All API responses are parsed through Zod at runtime; a schema mismatch throws immediately. When the upstream API changes, update the schema here.
+- **Endpoints** (`src/api/endpoints/`) — one class per resource. Endpoints only build requests (URL, query params, learner-ID injection). Every schema-validated method takes a **required Zod schema argument** and returns `z.output` of it; `getWithSchema`/`postWithSchema` `safeParse` and throw on mismatch.
+- **Catalog schemas** (`src/api/types/`) — documentation of known upstream response shapes, *not* an enforced contract. Modules derive feature schemas from them via `.pick()` so transforms (e.g. `dd/mm/yyyy` → `Date`) and field docs come along.
+- **Feature schemas** — each module owns a `schemas.ts` picking exactly the fields it needs (e.g. `src/modules/attendance-calculator/attendance-calculator.schemas.ts`). An upstream change to a field no module picks breaks nothing; a change to a picked field throws immediately, scoped to that module.
 
-> **Important:** The VIS InSchool API is entirely reverse-engineered — there is no official documentation. Response shapes can vary between students (different school configurations, roles, or data), so some Zod schemas are intentionally broad (e.g. `z.unknown()`, optional fields, loose unions) to avoid breaking for users whose accounts return different payloads. Do not tighten a schema unless you have verified the stricter shape against live data from multiple accounts. New schemas must also be validated via live testing using `window.testAllApiSchemas()` in the browser console.
->
-> `getWithSchema` / `postWithSchema` use `safeParse` rather than `parse`. On a schema mismatch they emit a `console.warn` and return the raw response cast as `T`, so features degrade gracefully instead of failing silently when the upstream API adds or changes fields.
+> **Important:** The VIS InSchool API is entirely reverse-engineered — there is no official documentation. Response shapes can vary between students (different school configurations, roles, or data), so keep catalog schemas broad (`z.unknown()`, optional fields, loose unions) unless the stricter shape is verified against live data from multiple accounts. When upstream adds/renames a field, update the catalog schema; picks referencing renamed/removed catalog keys then fail at compile time, pointing at exactly the affected features. Run `window.testAllApiSchemas()` in the browser console to validate the full catalog against live responses — it is the drift-detection net for fields no feature consumes.
 
 ### Features
 

--- a/docs/arkitektur.md
+++ b/docs/arkitektur.md
@@ -27,6 +27,14 @@ API-koden ligger i `src/api`. Endepunktene er delt etter fagområde, for eksempe
 
 Prosjektet bruker Zod for runtime-validering av data fra VIS InSchool. Det betyr at dataene ikke bare types i TypeScript, men også sjekkes når de kommer fra API-et.
 
+Siden API-et er udokumentert og ustabilt, er valideringen funksjonsdrevet:
+
+- Endepunktene bygger bare forespørsler (URL, parametere, pålogging). De tar imot et Zod-schema som et påkrevd argument og validerer svaret mot det.
+- Schemaene i `src/api/types` er en katalog over kjente felt i API-et, ikke en kontrakt som håndheves for hele svaret.
+- Hver modul har en egen `schemas.ts` som plukker (`pick`) feltene den faktisk bruker fra katalogen. Transformeringer og feltdokumentasjon følger med.
+
+En endring i et felt ingen moduler bruker, ødelegger derfor ingenting. En endring i et felt en modul bruker, feiler umiddelbart og synlig — bare for den modulen. `testAllApiSchemas()` (se Utvikling) sjekker hele katalogen mot det virkelige API-et og fanger opp endringer i feltene ingen bruker ennå.
+
 ## DOM-injisering
 
 Modulene legger UI inn i eksisterende VIS InSchool-sider. Dette skjer gjennom felles DOM-hjelpere og injectables.

--- a/docs/modul-eksempel.md
+++ b/docs/modul-eksempel.md
@@ -149,26 +149,51 @@ høyre. Hvis du navigerer bort fra dashboardet, fjernes panelet av
 ## Valgfritt: kall et API
 
 Når DOM-modulen fungerer, kan du legge til API-bruk. Dette eksempelet henter
-aktivt skoleår og skriver det til konsollen når modulen lastes:
+aktivt skoleår og skriver det til konsollen når modulen lastes.
+
+API-endepunktene validerer ikke hele svaret fra VIS. I stedet gir hver modul
+med sitt eget Zod-schema med akkurat feltene den trenger. Schemaet plukkes
+(`pick`) fra katalog-schemaene i `src/api/types`, slik at transformeringer
+(f.eks. datoer) og feltdokumentasjon følger med.
+
+Lag en `schemas.ts` i modulmappen:
+
+```typescript
+import { z } from "zod";
+import { AcademicYearSchema } from "../../api/types/calendar";
+
+export const MittSkoleaarSchema = z.array(
+  AcademicYearSchema.pick({
+    name: true,
+    currentYear: true,
+  }),
+);
+```
 
 Legg til disse importene øverst i samme modulfil:
 
 ```typescript
 import { api } from "../../api/api";
+import { MittSkoleaarSchema } from "./schemas";
 ```
 
 Legg deretter `onLoad` inn i `SimpleDashboardNote`-klassen:
 
 ```typescript
   override async onLoad(): Promise<void> {
-    const academicYear = await api.calendar.getCurrentAcademicYear();
+    const academicYear = await api.calendar.getCurrentAcademicYear(
+      MittSkoleaarSchema,
+    );
     this.logger.info("Aktivt skoleår:", academicYear.name);
   }
 ```
 
-API-laget bruker Zod til å validere data fra VIS InSchool. Hvis VIS endrer
-responsformatet sitt, kan API-kallet derfor feile selv om TypeScript-koden
-kompilerer.
+API-laget bruker Zod til å validere data fra VIS InSchool. Fordelen med å
+plukke bare det modulen trenger: hvis VIS endrer eller fjerner et felt modulen
+ikke bruker, fortsetter den å fungere. Mangler eller endres et felt modulen
+faktisk trenger, kastes en feil umiddelbart — selv om TypeScript-koden
+kompilerer. Trenger du et felt som ikke finnes i katalogen ennå, legg det til i
+`src/api/types` først og plukk det deretter.
 
 ## Vanlige feil
 

--- a/docs/utvikling.md
+++ b/docs/utvikling.md
@@ -75,7 +75,10 @@ Hvis VIS endrer API-et sitt, kan Zod-schemaene feile. Prosjektet eksponerer derf
 testAllApiSchemas()
 ```
 
-Kommandoen tester kjente API-endepunkter og skriver resultatet i konsollen.
+Kommandoen tester kjente API-endepunkter mot hele katalog-schemaene i
+`src/api/types` og skriver resultatet i konsollen. Moduler validerer bare
+feltene de selv bruker, så denne testen er nettet som fanger opp endringer i
+resten av API-et før noen trenger feltene.
 
 ## Runtime debug-info
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,4 +1,4 @@
-import { User } from "./types/user";
+import { z } from "zod";
 import { ApiClient } from "./apiClient";
 import { AttendanceApi } from "./endpoints/attendance";
 import { CalendarApi } from "./endpoints/calendar";
@@ -50,7 +50,10 @@ export class Session {
 
   async getLearnerId(): Promise<number> {
     if (this.learnerId != null) return this.learnerId;
-    const user: User = await this.user.getCurrentUser();
+    // Every feature funnels through here — validate only what we need.
+    const user = await this.user.getCurrentUser(
+      z.object({ learnerId: z.number() }),
+    );
     this.learnerId = user.learnerId;
     return this.learnerId;
   }

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,4 +1,4 @@
-import { ZodType } from "zod";
+import type { z, ZodType } from "zod";
 import { createLogger } from "../utils/logger";
 import { AuthProvider } from "./authProvider";
 
@@ -62,11 +62,11 @@ export class ApiClient {
     return this.request<T>(Method.POST, path, opts, body);
   }
 
-  async getWithSchema<T>(
+  async getWithSchema<S extends ZodType>(
     path: string,
-    schema: ZodType<T>,
+    schema: S,
     opts?: RequestOptions,
-  ) {
+  ): Promise<z.output<S>> {
     const json = await this.get(path, opts);
     const result = schema.safeParse(json);
     if (!result.success) {
@@ -76,12 +76,12 @@ export class ApiClient {
     return result.data;
   }
 
-  async postWithSchema<T>(
+  async postWithSchema<S extends ZodType>(
     path: string,
     body: unknown,
-    schema: ZodType<T>,
+    schema: S,
     opts?: RequestOptions,
-  ) {
+  ): Promise<z.output<S>> {
     const json = await this.post(path, body, opts);
     const result = schema.safeParse(json);
     if (!result.success) {

--- a/src/api/endpoints/assessment.ts
+++ b/src/api/endpoints/assessment.ts
@@ -1,25 +1,17 @@
 import { Endpoint } from "../endpoint";
-import {
-  Behaviour,
-  BehaviourSchema,
-  RemarkLimit,
-  RemarkLimitSchema,
-} from "../types/assessment";
+import type { z, ZodType } from "zod";
 
 export class AssessmentApi extends Endpoint {
-  async getBehaviour(): Promise<Behaviour> {
+  async getBehaviour<S extends ZodType>(schema: S): Promise<z.output<S>> {
     const learnerId = await this.session.getLearnerId();
 
     return this.client.getWithSchema(
       `assessment/behaviour/${learnerId}`,
-      BehaviourSchema,
+      schema,
     );
   }
 
-  async getRemarkLimit(): Promise<RemarkLimit> {
-    return this.client.getWithSchema(
-      `assessment/remark/limit`,
-      RemarkLimitSchema,
-    );
+  async getRemarkLimit<S extends ZodType>(schema: S): Promise<z.output<S>> {
+    return this.client.getWithSchema(`assessment/remark/limit`, schema);
   }
 }

--- a/src/api/endpoints/attendance.ts
+++ b/src/api/endpoints/attendance.ts
@@ -1,42 +1,29 @@
-import {
-  AbsenceCodesByTeachingGroups,
-  AbsenceCodesByTeachingGroupsSchema,
-  AbsenceOverview,
-  AttendanceSubjectGroup,
-  AttendanceSubjectGroupSchema,
-  DiplomaAbsences,
-  DiplomaAbsencesSchema,
-  DiplomaTermAbsences,
-  DiplomaTermAbsencesSchema,
-  LessonAttendance,
-  LessonAttendancesSchema,
-  MembershipFilter,
-  AbsenceOverviewSchema,
-} from "../types/attendance";
-import { AcademicYear } from "../types/calendar";
-import z from "zod";
+import type { MembershipFilter } from "../types/attendance";
+import type { z, ZodType } from "zod";
 import { Endpoint } from "../endpoint";
 
 export class AttendanceApi extends Endpoint {
-  async getAttendanceForSubjectGroups(
-    academicYear: AcademicYear,
-  ): Promise<AttendanceSubjectGroup[]> {
+  async getAttendanceForSubjectGroups<S extends ZodType>(
+    academicYear: { id: number },
+    schema: S,
+  ): Promise<z.output<S>> {
     const learnerId = await this.session.getLearnerId();
 
     return this.client.getWithSchema(
       `attendance/subject-groups/learner/${learnerId}/academic-year/${academicYear.id}`,
-      z.array(AttendanceSubjectGroupSchema),
+      schema,
     );
   }
 
-  async getAbsenceOverview(
+  async getAbsenceOverview<S extends ZodType>(
+    schema: S,
     membershipFilter: MembershipFilter = "MEMBER",
-  ): Promise<AbsenceOverview> {
+  ): Promise<z.output<S>> {
     const learnerId = await this.session.getLearnerId();
 
     return this.client.getWithSchema(
       `attendance/overview/learners/${learnerId}/absence-overview`,
-      AbsenceOverviewSchema,
+      schema,
       {
         query: {
           membershipFilter: membershipFilter,
@@ -45,14 +32,15 @@ export class AttendanceApi extends Endpoint {
     );
   }
 
-  async getAbsenceCodesByTeachingGroups(
+  async getAbsenceCodesByTeachingGroups<S extends ZodType>(
+    schema: S,
     membershipFilter: MembershipFilter = "MEMBER",
-  ): Promise<AbsenceCodesByTeachingGroups> {
+  ): Promise<z.output<S>> {
     const learnerId = await this.session.getLearnerId();
 
     return this.client.getWithSchema(
       `attendance/overview/learners/${learnerId}/absence-overview/codes-by-teaching-groups`,
-      AbsenceCodesByTeachingGroupsSchema,
+      schema,
       {
         query: {
           membershipFilter,
@@ -61,15 +49,16 @@ export class AttendanceApi extends Endpoint {
     );
   }
 
-  async getDiplomaAbsences(
-    academicYear: AcademicYear,
+  async getDiplomaAbsences<S extends ZodType>(
+    academicYear: { id: number },
+    schema: S,
     membershipFilter: MembershipFilter = "MEMBER",
-  ): Promise<DiplomaAbsences> {
+  ): Promise<z.output<S>> {
     const learnerId = await this.session.getLearnerId();
 
     return this.client.getWithSchema(
       `attendance/v2/learners/${learnerId}/diploma-absences/academic-year/${academicYear.id}`,
-      DiplomaAbsencesSchema,
+      schema,
       {
         query: {
           membershipFilter,
@@ -78,16 +67,17 @@ export class AttendanceApi extends Endpoint {
     );
   }
 
-  async getDiplomaAbsencesForTerm(
-    academicYear: AcademicYear,
+  async getDiplomaAbsencesForTerm<S extends ZodType>(
+    academicYear: { id: number },
     term: 1 | 2,
+    schema: S,
     membershipFilter: MembershipFilter = "MEMBER",
-  ): Promise<DiplomaTermAbsences> {
+  ): Promise<z.output<S>> {
     const learnerId = await this.session.getLearnerId();
 
     return this.client.getWithSchema(
       `attendance/v2/learners/${learnerId}/diploma-absences/academic-year/${academicYear.id}/term/${term}`,
-      DiplomaTermAbsencesSchema,
+      schema,
       {
         query: {
           membershipFilter,
@@ -96,17 +86,18 @@ export class AttendanceApi extends Endpoint {
     );
   }
 
-  async getLessonAttendancesForTeachingGroups(
-    academicYear: AcademicYear,
+  async getLessonAttendancesForTeachingGroups<S extends ZodType>(
+    academicYear: { id: number },
     subjectGroupIds: number[],
-  ): Promise<LessonAttendance[]> {
-    if (subjectGroupIds.length === 0) return [];
+    schema: S,
+  ): Promise<z.output<S>> {
+    if (subjectGroupIds.length === 0) return [] as z.output<S>;
 
     const learnerId = await this.session.getLearnerId();
 
     return this.client.getWithSchema(
       `attendance/v2/lesson/learner/${learnerId}/academic-year/${academicYear.id}/teaching-groups`,
-      LessonAttendancesSchema,
+      schema,
       {
         query: {
           teachingGroupIds: subjectGroupIds.join(","),

--- a/src/api/endpoints/calendar.ts
+++ b/src/api/endpoints/calendar.ts
@@ -1,25 +1,20 @@
-import {
-  AcademicYear,
-  AcademicYearSchema,
-  DayCount,
-  DayCountSchema,
-  type Term,
-} from "../types/calendar";
-import z from "zod";
+import type { z, ZodType } from "zod";
 import { Endpoint } from "../endpoint";
 
 export class CalendarApi extends Endpoint {
-  async getAcademicYears(): Promise<AcademicYear[]> {
+  async getAcademicYears<S extends ZodType>(schema: S): Promise<z.output<S>> {
     const learnerId = await this.session.getLearnerId();
 
     return this.client.getWithSchema(
       `calendar/v2/academicyears/learner/${learnerId}`,
-      z.array(AcademicYearSchema),
+      schema,
     );
   }
 
-  async getCurrentAcademicYear(): Promise<AcademicYear> {
-    const academicYears = await this.getAcademicYears();
+  async getCurrentAcademicYear<S extends ZodType<{ currentYear: boolean }[]>>(
+    schema: S,
+  ): Promise<z.output<S>[number]> {
+    const academicYears = await this.getAcademicYears(schema);
     const currentYear = academicYears.find((year) => year.currentYear);
     if (!currentYear) {
       throw new Error("No current academic year available.");
@@ -27,7 +22,9 @@ export class CalendarApi extends Endpoint {
     return currentYear;
   }
 
-  getCurrentTerm(academicYear: AcademicYear): Term {
+  getCurrentTerm<T extends { current: boolean }>(academicYear: {
+    terms: T[];
+  }): T {
     const currentTerm = academicYear.terms.find((term) => term.current);
     if (!currentTerm) {
       throw new Error("No current term available.");
@@ -36,10 +33,13 @@ export class CalendarApi extends Endpoint {
   }
 
   // Get the amount of learning days, vacation days, and planning days.
-  async getDayCount(academicYear: AcademicYear): Promise<DayCount> {
+  async getDayCount<S extends ZodType>(
+    academicYear: { id: number },
+    schema: S,
+  ): Promise<z.output<S>> {
     return this.client.getWithSchema(
       `calendar/v2/academicyears/${academicYear.id}/daycount`,
-      DayCountSchema,
+      schema,
     );
   }
 }

--- a/src/api/endpoints/events.ts
+++ b/src/api/endpoints/events.ts
@@ -1,13 +1,15 @@
-import z from "zod";
-import { Event, EventSchema } from "../types/events";
+import type { z, ZodType } from "zod";
 import { Endpoint } from "../endpoint";
 
 export class EventsApi extends Endpoint {
-  async getEvents(): Promise<Event[]> {
-    return this.client.getWithSchema("events", z.array(EventSchema));
+  async getEvents<S extends ZodType>(schema: S): Promise<z.output<S>> {
+    return this.client.getWithSchema("events", schema);
   }
 
-  async getEvent(eventId: number): Promise<Event> {
-    return this.client.getWithSchema(`events/${eventId}`, EventSchema);
+  async getEvent<S extends ZodType>(
+    eventId: number,
+    schema: S,
+  ): Promise<z.output<S>> {
+    return this.client.getWithSchema(`events/${eventId}`, schema);
   }
 }

--- a/src/api/endpoints/exams.ts
+++ b/src/api/endpoints/exams.ts
@@ -1,13 +1,13 @@
 import { Endpoint } from "../endpoint";
-import { ExamGroups, ExamGroupsSchema } from "../types/exams";
+import type { z, ZodType } from "zod";
 
 export class ExamsApi extends Endpoint {
-  async getGroups(): Promise<ExamGroups> {
+  async getGroups<S extends ZodType>(schema: S): Promise<z.output<S>> {
     const learnerId = await this.session.getLearnerId();
 
     return this.client.getWithSchema(
       `norway/exams/learner/${learnerId}/groups`,
-      ExamGroupsSchema,
+      schema,
     );
   }
 }

--- a/src/api/endpoints/inbox.ts
+++ b/src/api/endpoints/inbox.ts
@@ -1,13 +1,15 @@
 import { Endpoint } from "../endpoint";
-import { FilterType, Messages, MessagesSchema } from "../types/inbox";
+import type { FilterType } from "../types/inbox";
+import type { z, ZodType } from "zod";
 
 export class InboxApi extends Endpoint {
-  async getMessages(
+  async getMessages<S extends ZodType>(
+    schema: S,
     page: number = 0,
     pageSize: number = 1000,
     filterType: FilterType = "ALL",
-  ): Promise<Messages> {
-    return this.client.getWithSchema("inbox/messages", MessagesSchema, {
+  ): Promise<z.output<S>> {
+    return this.client.getWithSchema("inbox/messages", schema, {
       query: {
         page,
         pageSize,

--- a/src/api/endpoints/login-page.ts
+++ b/src/api/endpoints/login-page.ts
@@ -1,8 +1,8 @@
 import { Endpoint } from "../endpoint";
-import { LoginPage, LoginPageSchema } from "../types/login-page";
+import type { z, ZodType } from "zod";
 
 export class LoginPageApi extends Endpoint {
-  async getLoginPage(): Promise<LoginPage> {
-    return this.client.getWithSchema("login-page", LoginPageSchema);
+  async getLoginPage<S extends ZodType>(schema: S): Promise<z.output<S>> {
+    return this.client.getWithSchema("login-page", schema);
   }
 }

--- a/src/api/endpoints/school.ts
+++ b/src/api/endpoints/school.ts
@@ -1,8 +1,8 @@
-import { School, SchoolSchema } from "../types/school";
 import { Endpoint } from "../endpoint";
+import type { z, ZodType } from "zod";
 
 export class SchoolApi extends Endpoint {
-  async getCurrent(): Promise<School> {
-    return this.client.getWithSchema("schoolinfo/current", SchoolSchema);
+  async getCurrent<S extends ZodType>(schema: S): Promise<z.output<S>> {
+    return this.client.getWithSchema("schoolinfo/current", schema);
   }
 }

--- a/src/api/endpoints/tenant.ts
+++ b/src/api/endpoints/tenant.ts
@@ -1,11 +1,10 @@
-import z from "zod";
-import { Tenant, TenantSchema } from "../types/tenant";
+import type { z, ZodType } from "zod";
 import { Endpoint } from "../endpoint";
 
 export class TenantApi extends Endpoint {
   // This endpoint is publicly accessible and requires no authentication.
   // NB: This has to be called from a tenant's url, not callable from the base url "inschool.visma.no"
-  async getTenantlist(): Promise<Tenant[]> {
-    return this.client.getWithSchema("tenant/list", z.array(TenantSchema));
+  async getTenantlist<S extends ZodType>(schema: S): Promise<z.output<S>> {
+    return this.client.getWithSchema("tenant/list", schema);
   }
 }

--- a/src/api/endpoints/timetable.ts
+++ b/src/api/endpoints/timetable.ts
@@ -1,31 +1,26 @@
-import {
-  ActivityDetail,
-  ActivityDetailSchema,
-  Timetable,
-  TimetableSchema,
-  TimetableType,
-  TimetableTypeSchema,
-} from "../types/timetable";
-import z from "zod";
+import { TimetableType, TimetableTypeSchema } from "../types/timetable";
+import type { z, ZodType } from "zod";
 import { Endpoint } from "../endpoint";
 
 export class TimetableApi extends Endpoint {
   /**
    *
    * @param week A date which is in the week you want to get the timetable for.
+   * @param schema Feature-driven Zod schema; only the fields the caller needs are validated.
    * @param types Types of info to get from the timetable endpoint.
    * @param extraInfo
    */
-  async getTimetable(
+  async getTimetable<S extends ZodType>(
     week: Date,
+    schema: S,
     types: TimetableType[] = [
-      TimetableTypeSchema.enum.LESSON, 
-      TimetableTypeSchema.enum.EVENT, 
-      TimetableTypeSchema.enum.ACTIVITY, 
+      TimetableTypeSchema.enum.LESSON,
+      TimetableTypeSchema.enum.EVENT,
+      TimetableTypeSchema.enum.ACTIVITY,
       TimetableTypeSchema.enum.SUBSTITUTION
     ],
     extraInfo = true, // Purpose currently unknown, returns same json.
-  ): Promise<Timetable> {
+  ): Promise<z.output<S>> {
     const learnerId = await this.session.getLearnerId();
 
     // dd/mm/yyyy
@@ -33,7 +28,7 @@ export class TimetableApi extends Endpoint {
 
     return this.client.getWithSchema(
       `timetablev2/learner/${learnerId}/fetch/ALL/0/current`,
-      TimetableSchema,
+      schema,
       {
         query: {
           forWeek: dateStr,
@@ -47,14 +42,16 @@ export class TimetableApi extends Endpoint {
   /**
    * Posts a list of activityTimeslotIds to get additional activity details.
    * @param activityTimeslotIds - Array of activity timeslot IDs to get details for
+   * @param schema Feature-driven Zod schema; only the fields the caller needs are validated.
    */
-  async postAdditionalActivityDetails(
+  async postAdditionalActivityDetails<S extends ZodType>(
     activityTimeslotIds: number[],
-  ): Promise<ActivityDetail[]> {
+    schema: S,
+  ): Promise<z.output<S>> {
     return this.client.postWithSchema(
       "timetablev2/additional-activity-details",
       activityTimeslotIds,
-      z.array(ActivityDetailSchema),
+      schema,
     );
   }
 }

--- a/src/api/endpoints/user.ts
+++ b/src/api/endpoints/user.ts
@@ -1,35 +1,27 @@
-import {
-  PersonalInfo,
-  PersonalInfoSchema,
-  User,
-  UserSchema,
-} from "../types/user";
+import type { z, ZodType } from "zod";
 import { Endpoint } from "../endpoint";
 
 export class UserApi extends Endpoint {
-  async getCurrentUser(): Promise<User> {
-    return this.client.getWithSchema("permissions/user", UserSchema);
+  async getCurrentUser<S extends ZodType>(schema: S): Promise<z.output<S>> {
+    return this.client.getWithSchema("permissions/user", schema);
   }
 
-  async getPersonalInfo(
+  async getPersonalInfo<S extends ZodType>(
+    schema: S,
     filterType: string = "ALL",
     filterId: number = 0,
     action: string = "current",
-  ): Promise<PersonalInfo> {
+  ): Promise<z.output<S>> {
     const learnerId = await this.session.getLearnerId();
     // ?filterType=ALL&filterId=0&action=current
 
-    return this.client.getWithSchema(
-      `learner/${learnerId}/personal`,
-      PersonalInfoSchema,
-      {
-        query: {
-          filterType,
-          filterId,
-          action,
-        },
+    return this.client.getWithSchema(`learner/${learnerId}/personal`, schema, {
+      query: {
+        filterType,
+        filterId,
+        action,
       },
-    );
+    });
   }
 
   async getMaturity(): Promise<boolean> {

--- a/src/api/testSchemas.ts
+++ b/src/api/testSchemas.ts
@@ -1,6 +1,28 @@
 import { api } from "./api";
-import { ZodError } from "zod";
+import { z, ZodError } from "zod";
 import { createLogger } from "../utils/logger";
+import { BehaviourSchema, RemarkLimitSchema } from "./types/assessment";
+import {
+  AbsenceCodesByTeachingGroupsSchema,
+  AbsenceOverviewSchema,
+  AttendanceSubjectGroupSchema,
+  DiplomaAbsencesSchema,
+  DiplomaTermAbsencesSchema,
+  LessonAttendancesSchema,
+} from "./types/attendance";
+import { AcademicYearSchema, DayCountSchema } from "./types/calendar";
+import { EventSchema } from "./types/events";
+import { ExamGroupsSchema } from "./types/exams";
+import { MessagesSchema } from "./types/inbox";
+import { LoginPageSchema } from "./types/login-page";
+import { SchoolSchema } from "./types/school";
+import { TenantSchema } from "./types/tenant";
+import { TimetableSchema } from "./types/timetable";
+import { PersonalInfoSchema, UserSchema } from "./types/user";
+
+// Features validate only the fields they need (feature-driven schemas).
+// This suite passes the full catalog schemas to detect upstream API drift
+// in fields no feature consumes yet.
 
 const logger = createLogger("ApiSchemas");
 
@@ -52,16 +74,16 @@ export async function testAllApiSchemas(): Promise<void> {
 
   // Test UserApi methods
   await testApiCall("UserApi.getCurrentUser()", () =>
-    api.user.getCurrentUser(),
+    api.user.getCurrentUser(UserSchema),
   );
   await testApiCall("UserApi.getPersonalInfo()", () =>
-    api.user.getPersonalInfo(),
+    api.user.getPersonalInfo(PersonalInfoSchema),
   );
   await testApiCall("UserApi.getMaturity()", () => api.user.getMaturity());
 
   // Test TimetableApi methods
   await testApiCall("TimetableApi.getTimetable()", () =>
-    api.timetable.getTimetable(new Date()),
+    api.timetable.getTimetable(new Date(), TimetableSchema),
   );
   // Skipping postAdditionalActivityDetails - requires activityTimeslotIds parameter
   skipTest(
@@ -71,7 +93,7 @@ export async function testAllApiSchemas(): Promise<void> {
 
   // Test CalendarApi methods
   const academicYears = await testApiCall("CalendarApi.getAcademicYears()", () =>
-    api.calendar.getAcademicYears(),
+    api.calendar.getAcademicYears(z.array(AcademicYearSchema)),
   );
 
   // Test getDayCount with the first academic year if available
@@ -81,7 +103,7 @@ export async function testAllApiSchemas(): Promise<void> {
       skipTest("CalendarApi.getDayCount()", "no academic years available");
     } else {
       await testApiCall("CalendarApi.getDayCount()", () =>
-        api.calendar.getDayCount(firstAcademicYear),
+        api.calendar.getDayCount(firstAcademicYear, DayCountSchema),
       );
     }
   } else {
@@ -90,10 +112,12 @@ export async function testAllApiSchemas(): Promise<void> {
 
   // Test AttendanceApi methods
   await testApiCall("AttendanceApi.getAbsenceOverview()", () =>
-    api.attendance.getAbsenceOverview(),
+    api.attendance.getAbsenceOverview(AbsenceOverviewSchema),
   );
   await testApiCall("AttendanceApi.getAbsenceCodesByTeachingGroups()", () =>
-    api.attendance.getAbsenceCodesByTeachingGroups(),
+    api.attendance.getAbsenceCodesByTeachingGroups(
+      AbsenceCodesByTeachingGroupsSchema,
+    ),
   );
 
   if (academicYears && academicYears.length > 0) {
@@ -118,13 +142,18 @@ export async function testAllApiSchemas(): Promise<void> {
     } else {
       const attendanceGroups = await testApiCall(
         "AttendanceApi.getAttendanceForSubjectGroups()",
-        () => api.attendance.getAttendanceForSubjectGroups(firstAcademicYear),
+        () =>
+          api.attendance.getAttendanceForSubjectGroups(
+            firstAcademicYear,
+            z.array(AttendanceSubjectGroupSchema),
+          ),
       );
       if (attendanceGroups && attendanceGroups.length > 0) {
         await testApiCall("AttendanceApi.getLessonAttendancesForTeachingGroups()", () =>
           api.attendance.getLessonAttendancesForTeachingGroups(
             firstAcademicYear,
             attendanceGroups.map((g) => g.subjectGroupId),
+            LessonAttendancesSchema,
           ),
         );
       } else {
@@ -134,10 +163,14 @@ export async function testAllApiSchemas(): Promise<void> {
         );
       }
       await testApiCall("AttendanceApi.getDiplomaAbsences()", () =>
-        api.attendance.getDiplomaAbsences(firstAcademicYear),
+        api.attendance.getDiplomaAbsences(firstAcademicYear, DiplomaAbsencesSchema),
       );
       await testApiCall("AttendanceApi.getDiplomaAbsencesForTerm(1)", () =>
-        api.attendance.getDiplomaAbsencesForTerm(firstAcademicYear, 1),
+        api.attendance.getDiplomaAbsencesForTerm(
+          firstAcademicYear,
+          1,
+          DiplomaTermAbsencesSchema,
+        ),
       );
     }
   } else {
@@ -160,33 +193,41 @@ export async function testAllApiSchemas(): Promise<void> {
   }
 
   // Test SchoolApi methods
-  await testApiCall("SchoolApi.getCurrent()", () => api.school.getCurrent());
+  await testApiCall("SchoolApi.getCurrent()", () =>
+    api.school.getCurrent(SchoolSchema),
+  );
 
   // Test TenantApi methods
-  await testApiCall("TenantApi.getTenantlist()", () => api.tenant.getTenantlist());
+  await testApiCall("TenantApi.getTenantlist()", () =>
+    api.tenant.getTenantlist(z.array(TenantSchema)),
+  );
 
   // Test AssessmentApi methods
   await testApiCall("AssessmentApi.getBehaviour()", () =>
-    api.assessment.getBehaviour(),
+    api.assessment.getBehaviour(BehaviourSchema),
   );
   await testApiCall("AssessmentApi.getRemarkLimit()", () =>
-    api.assessment.getRemarkLimit(),
+    api.assessment.getRemarkLimit(RemarkLimitSchema),
   );
 
   // Test ExamsApi methods
-  await testApiCall("ExamsApi.getGroups()", () => api.exams.getGroups());
+  await testApiCall("ExamsApi.getGroups()", () =>
+    api.exams.getGroups(ExamGroupsSchema),
+  );
 
   // Test InboxApi methods
-  await testApiCall("InboxApi.getMessages()", () => api.inbox.getMessages());
+  await testApiCall("InboxApi.getMessages()", () =>
+    api.inbox.getMessages(MessagesSchema),
+  );
   await testApiCall("InboxApi.getNewCount()", () => api.inbox.getNewCount());
 
   // Test EventsApi methods
   const events = await testApiCall("EventsApi.getEvents()", () =>
-    api.events.getEvents(),
+    api.events.getEvents(z.array(EventSchema)),
   );
 
   await testApiCall("LoginPageApi.getLoginPage()", () =>
-    api.loginPage.getLoginPage(),
+    api.loginPage.getLoginPage(LoginPageSchema),
   );
 
   // Also test getEvent with the first event if available
@@ -196,7 +237,7 @@ export async function testAllApiSchemas(): Promise<void> {
       skipTest("EventsApi.getEvent(id)", "no events available");
     } else {
       await testApiCall(`EventsApi.getEvent(${firstEvent.id})`, () =>
-        api.events.getEvent(firstEvent.id),
+        api.events.getEvent(firstEvent.id, EventSchema),
       );
     }
   } else {

--- a/src/debuginfo.ts
+++ b/src/debuginfo.ts
@@ -1,4 +1,5 @@
 import { api } from "./api/api";
+import { LoginPageSchema } from "./api/types/login-page";
 import { version } from "../package.json" with { type: "json" };
 
 export async function printDebugInfo(): Promise<void> {
@@ -6,7 +7,7 @@ export async function printDebugInfo(): Promise<void> {
   console.log("Version:", version);
 
   try {
-    const loginPage = await api.loginPage.getLoginPage();
+    const loginPage = await api.loginPage.getLoginPage(LoginPageSchema);
 
     console.log("Valid VIS tenant:", loginPage.validUrl);
 

--- a/src/modules/attendance-calculator/attendance-calculator.data.ts
+++ b/src/modules/attendance-calculator/attendance-calculator.data.ts
@@ -1,11 +1,15 @@
 import { api } from "../../api/api";
-import type { AcademicYear } from "../../api/types/calendar";
-import type {
-  AttendanceSubjectGroup,
-  LessonAttendance,
-} from "../../api/types/attendance";
-import type { TimetableItem } from "../../api/types/timetable";
 import { startOfWeek } from "../../utils/time";
+import {
+  CalcAcademicYearsSchema,
+  CalcLessonAttendancesSchema,
+  CalcSubjectGroupsSchema,
+  CalcTimetableSchema,
+  type CalcAcademicYear,
+  type CalcLessonAttendance,
+  type CalcSubjectGroup,
+  type CalcTimetableItem,
+} from "./attendance-calculator.schemas";
 import {
   absenceBasisHours,
   attendanceCodeCountsTowardsLimit,
@@ -17,13 +21,18 @@ import {
 } from "./attendance-calculator.helpers";
 
 export interface AttendanceCalculatorBaseData {
-  currentYear: AcademicYear;
-  groups: AttendanceSubjectGroup[];
+  currentYear: CalcAcademicYear;
+  groups: CalcSubjectGroup[];
 }
 
 export async function loadCurrentAttendanceGroups(): Promise<AttendanceCalculatorBaseData> {
-  const currentYear = await api.calendar.getCurrentAcademicYear();
-  const groups = await api.attendance.getAttendanceForSubjectGroups(currentYear);
+  const currentYear = await api.calendar.getCurrentAcademicYear(
+    CalcAcademicYearsSchema,
+  );
+  const groups = await api.attendance.getAttendanceForSubjectGroups(
+    currentYear,
+    CalcSubjectGroupsSchema,
+  );
   return {
     currentYear,
     groups: groups.filter((g) => absenceBasisHours(g) > 0),
@@ -54,14 +63,15 @@ export async function loadAttendanceCalculatorState(
 
 export async function loadAttendanceCalculatorLessons(
   week: Date,
-  currentYear: AcademicYear,
-  groups: AttendanceSubjectGroup[],
+  currentYear: CalcAcademicYear,
+  groups: CalcSubjectGroup[],
 ): Promise<SelectableLesson[]> {
   const [timetable, lessonAttendances] = await Promise.all([
-    api.timetable.getTimetable(week),
+    api.timetable.getTimetable(week, CalcTimetableSchema),
     api.attendance.getLessonAttendancesForTeachingGroups(
       currentYear,
       groups.map((g) => g.subjectGroupId),
+      CalcLessonAttendancesSchema,
     ),
   ]);
 
@@ -73,9 +83,9 @@ export async function loadAttendanceCalculatorLessons(
 }
 
 export function createSelectableLessons(
-  timetableItems: TimetableItem[],
-  groups: AttendanceSubjectGroup[],
-  lessonAttendances: LessonAttendance[] = [],
+  timetableItems: CalcTimetableItem[],
+  groups: CalcSubjectGroup[],
+  lessonAttendances: CalcLessonAttendance[] = [],
 ): SelectableLesson[] {
   const groupBySubjectCode = new Map(groups.map((g) => [g.subjectCode, g]));
   const groupById = new Map(groups.map((g) => [g.subjectGroupId, g]));
@@ -117,8 +127,8 @@ export function createSelectableLessons(
 }
 
 function lessonAttendanceStatusForItem(
-  item: TimetableItem,
-  attendanceByTimetableItemId: Map<string, LessonAttendance>,
+  item: CalcTimetableItem,
+  attendanceByTimetableItemId: Map<string, CalcLessonAttendance>,
 ): Pick<
   SelectableLesson,
   | "attendanceCode"

--- a/src/modules/attendance-calculator/attendance-calculator.demo-data.ts
+++ b/src/modules/attendance-calculator/attendance-calculator.demo-data.ts
@@ -1,9 +1,4 @@
-import type {
-  AttendanceCode,
-  AttendanceSubjectGroup,
-} from "../../api/types/attendance";
-import type { AcademicYear } from "../../api/types/calendar";
-import type { TimetableItem } from "../../api/types/timetable";
+import type { AttendanceCode } from "../../api/types/attendance";
 import { startOfWeek } from "../../utils/time";
 import {
   type AttendanceCalculatorState,
@@ -11,45 +6,19 @@ import {
   lessonDurationHours,
   type SelectableLesson,
 } from "./attendance-calculator.helpers";
+import type {
+  CalcAcademicYear,
+  CalcSubjectGroup,
+  CalcTimetableItem,
+} from "./attendance-calculator.schemas";
 
-const demoYear: AcademicYear = {
+const demoYear: CalcAcademicYear = {
   id: 20252026,
-  version: 1,
-  tenant: 1,
-  code: "20252026",
   name: "Skoleåret 2025/2026",
-  studentStartDate: new Date(2025, 7, 18),
   currentYear: true,
-  terms: [
-    {
-      id: 1,
-      version: 1,
-      startDate: new Date(2025, 7, 18),
-      endDate: new Date(2026, 0, 16),
-      code: "H1",
-      name: "Termin 1",
-      term: "TERM1",
-      current: false,
-    },
-    {
-      id: 2,
-      version: 1,
-      startDate: new Date(2026, 0, 19),
-      endDate: new Date(2026, 5, 19),
-      code: "H2",
-      name: "Termin 2",
-      term: "TERM2",
-      current: true,
-    },
-  ],
-  year: 2026,
-  daysInCycle: 5,
-  editable: false,
-  startDate: new Date(2025, 7, 18),
-  endDate: new Date(2026, 5, 19),
 };
 
-const groups: AttendanceSubjectGroup[] = [
+const groups: CalcSubjectGroup[] = [
   subjectGroup("MAT1023", "Matematikk 2P", "Matematikk", 112, 112.7, 4.5),
   subjectGroup("NOR1267", "Norsk hovedmål", "Norsk", 112, 112.7, 9.5),
   subjectGroup("ITK2002", "Informasjonsteknologi 1", "IT", 84, 84.5, 2),
@@ -122,34 +91,17 @@ function subjectGroup(
   yearlyHours: number,
   totalScheduledHours: number,
   totalAbsence: number,
-): AttendanceSubjectGroup {
-  const absencePercentage = (totalAbsence / yearlyHours) * 100;
-
+): CalcSubjectGroup {
   return {
     subjectGroupId: Number(subjectCode.replace(/\D/g, "")),
-    learnerPersonalId: 1,
-    subjectGroupName: `2ITA/${subjectCode}/1`,
     subjectCode,
     subjectName,
     subjectShortName,
     warningLimit: 8,
     defaultLimit: 10,
-    schoolName: "Inskewl videregående skole",
-    mainSchool: true,
-    learnerInTeachingGroup: true,
-    externalSchool: false,
     yearlyHours,
-    scheduledHoursTermOne: totalScheduledHours / 2,
     totalScheduledHours,
-    totalAbsenceTermOne: totalAbsence / 2,
-    totalAbsenceTermTwo: totalAbsence / 2,
     totalAbsence,
-    absencePercentageTermOne: absencePercentage,
-    absencePercentageTermOneAndTwo: absencePercentage,
-    threshold: {
-      absenceLimitExceededLast: null,
-      remainingPercentage: Math.max(0, 10 - absencePercentage),
-    },
   };
 }
 
@@ -167,33 +119,18 @@ function lesson(
     description: string;
   },
 ): SelectableLesson {
-  const item: TimetableItem = {
+  const item: CalcTimetableItem = {
     id,
     startTime,
     endTime,
     date: demoWeekday(weekStart, dayOffset),
-    tenant: 1,
-    academicYearId: demoYear.id,
-    entityId: 1000 + id,
     label: `2ITA/${subjectCode}/1`,
     type: "LESSON",
     originalType: null,
-    locations: ["Demo"],
-    mainRoom: "D-101",
-    additionalRooms: [],
     colour,
     teachingGroupId: 2000 + id,
-    blockName: null,
-    blockId: null,
-    blockDescription: null,
     subject,
     subjectCode,
-    assessment: null,
-    hasFutureAbsence: false,
-    teacherName: "Demo Lærer",
-    teachers: ["Demo Lærer"],
-    extraInfo: null,
-    periodNumberInDay: null,
   };
 
   return {

--- a/src/modules/attendance-calculator/attendance-calculator.helpers.ts
+++ b/src/modules/attendance-calculator/attendance-calculator.helpers.ts
@@ -1,10 +1,10 @@
-import type { TimetableItem } from "../../api/types/timetable";
-import type {
-  AttendanceCode,
-  AttendanceSubjectGroup,
-} from "../../api/types/attendance";
-import type { AcademicYear } from "../../api/types/calendar";
+import type { AttendanceCode } from "../../api/types/attendance";
 import { timeToMinutes } from "../../utils/time";
+import type {
+  CalcAcademicYear,
+  CalcSubjectGroup,
+  CalcTimetableItem,
+} from "./attendance-calculator.schemas";
 
 export interface SubjectAbsenceInfo {
   subjectCode: string;
@@ -19,7 +19,7 @@ export interface SubjectAbsenceInfo {
 }
 
 export interface SelectableLesson {
-  item: TimetableItem;
+  item: CalcTimetableItem;
   durationHours: number;
   selected: boolean;
   attendanceCode: AttendanceCode | null;
@@ -29,13 +29,13 @@ export interface SelectableLesson {
 }
 
 export interface AttendanceCalculatorState {
-  currentYear: AcademicYear;
-  groups: AttendanceSubjectGroup[];
+  currentYear: CalcAcademicYear;
+  groups: CalcSubjectGroup[];
   lessons: SelectableLesson[];
   selectedWeek: Date;
 }
 
-export function lessonDurationHours(item: TimetableItem): number {
+export function lessonDurationHours(item: CalcTimetableItem): number {
   return (timeToMinutes(item.endTime) - timeToMinutes(item.startTime)) / 60;
 }
 
@@ -47,14 +47,14 @@ export function extractSubjectCodeFromLabel(
   return match?.[1]?.toUpperCase() ?? null;
 }
 
-export function isLessonLike(item: TimetableItem): boolean {
+export function isLessonLike(item: CalcTimetableItem): boolean {
   return item.type === "LESSON" || (
     item.type === "SUBSTITUTION" &&
     item.originalType === "LESSON"
   );
 }
 
-export function resolveTimetableSubjectCode(item: TimetableItem): string | null {
+export function resolveTimetableSubjectCode(item: CalcTimetableItem): string | null {
   return item.subjectCode ?? extractSubjectCodeFromLabel(item.label);
 }
 
@@ -65,7 +65,7 @@ export function attendanceCodeCountsTowardsLimit(
   return code !== "D" && code !== "!" && code !== "R" && code !== "§";
 }
 
-export function absenceBasisHours(group: AttendanceSubjectGroup): number {
+export function absenceBasisHours(group: CalcSubjectGroup): number {
   return group.yearlyHours > 0 ? group.yearlyHours : group.totalScheduledHours;
 }
 
@@ -93,7 +93,7 @@ export function canSimulateLessonAbsenceAt(
 }
 
 export function computeAbsenceInfo(
-  group: AttendanceSubjectGroup,
+  group: CalcSubjectGroup,
   extraHours = 0,
 ): SubjectAbsenceInfo {
   const basisHours = absenceBasisHours(group);
@@ -127,7 +127,7 @@ export function computeAbsenceInfo(
 }
 
 export function canSkipLesson(
-  group: AttendanceSubjectGroup | undefined,
+  group: CalcSubjectGroup | undefined,
   lessonHours: number,
 ): { safe: boolean; newPct: number } {
   if (!group) {

--- a/src/modules/attendance-calculator/attendance-calculator.impl.ts
+++ b/src/modules/attendance-calculator/attendance-calculator.impl.ts
@@ -1,5 +1,7 @@
-import type { AcademicYear } from "../../api/types/calendar";
-import type { AttendanceSubjectGroup } from "../../api/types/attendance";
+import type {
+  CalcAcademicYear,
+  CalcSubjectGroup,
+} from "./attendance-calculator.schemas";
 import type { Injectable } from "../core/Injectable";
 import { dropdownAction } from "../core/injectables";
 import { VismaModule } from "../core/VismaModule";
@@ -17,10 +19,10 @@ export class AttendanceCalculator extends VismaModule implements AttendanceCalcu
   description: string = "Beregn gjenstående fravær per fag.";
 
   panel: HTMLElement | null = null;
-  groups: AttendanceSubjectGroup[] = [];
+  groups: CalcSubjectGroup[] = [];
   lessons: SelectableLesson[] = [];
   contentEl: HTMLElement | null = null;
-  currentYear: AcademicYear | null = null;
+  currentYear: CalcAcademicYear | null = null;
   selectedWeek: Date | null = null;
 
   private readonly view = new AttendanceCalculatorView(this);

--- a/src/modules/attendance-calculator/attendance-calculator.schemas.ts
+++ b/src/modules/attendance-calculator/attendance-calculator.schemas.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import {
+  AttendanceSubjectGroupSchema,
+  LessonAttendanceSchema,
+} from "../../api/types/attendance";
+import { AcademicYearSchema } from "../../api/types/calendar";
+import { TimetableItemSchema } from "../../api/types/timetable";
+
+/**
+ * Feature-driven schemas: validate only the fields the calculator needs.
+ * Fields are picked from the catalog schemas in src/api/types so transforms
+ * (e.g. dd/mm/yyyy -> Date) come along.
+ */
+export const CalcSubjectGroupSchema = AttendanceSubjectGroupSchema.pick({
+  subjectGroupId: true,
+  subjectCode: true,
+  subjectName: true,
+  subjectShortName: true,
+  yearlyHours: true,
+  totalScheduledHours: true,
+  totalAbsence: true,
+  warningLimit: true,
+  defaultLimit: true,
+});
+
+export const CalcSubjectGroupsSchema = z.array(CalcSubjectGroupSchema);
+
+export const CalcTimetableItemSchema = TimetableItemSchema.pick({
+  id: true,
+  type: true,
+  originalType: true,
+  subjectCode: true,
+  subject: true,
+  label: true,
+  teachingGroupId: true,
+  date: true,
+  startTime: true,
+  endTime: true,
+  colour: true,
+});
+
+export const CalcTimetableSchema = z.object({
+  timetableItems: z.array(CalcTimetableItemSchema),
+});
+
+export const CalcLessonAttendancesSchema = z.array(
+  LessonAttendanceSchema.pick({
+    timetableItemId: true,
+    attendanceCode: true,
+    attendanceCodeDescription: true,
+  }),
+);
+
+export const CalcAcademicYearsSchema = z.array(
+  AcademicYearSchema.pick({
+    id: true,
+    name: true,
+    currentYear: true,
+  }),
+);
+
+export type CalcSubjectGroup = z.infer<typeof CalcSubjectGroupSchema>;
+export type CalcTimetableItem = z.infer<typeof CalcTimetableItemSchema>;
+export type CalcLessonAttendance = z.infer<
+  typeof CalcLessonAttendancesSchema
+>[number];
+export type CalcAcademicYear = z.infer<typeof CalcAcademicYearsSchema>[number];

--- a/src/modules/attendance-calculator/attendance-calculator.view.ts
+++ b/src/modules/attendance-calculator/attendance-calculator.view.ts
@@ -1,5 +1,7 @@
-import type { AttendanceSubjectGroup } from "../../api/types/attendance";
-import type { AcademicYear } from "../../api/types/calendar";
+import type {
+  CalcAcademicYear,
+  CalcSubjectGroup,
+} from "./attendance-calculator.schemas";
 import { cx } from "../core/ui/classes";
 import { installInskewlUi } from "../core/ui/install";
 import { pct as cssPct, px, setCssVars } from "../core/ui/styleVars";
@@ -34,10 +36,10 @@ import {
 
 export interface AttendanceCalculatorController {
   panel: HTMLElement | null;
-  groups: AttendanceSubjectGroup[];
+  groups: CalcSubjectGroup[];
   lessons: SelectableLesson[];
   contentEl: HTMLElement | null;
-  currentYear: AcademicYear | null;
+  currentYear: CalcAcademicYear | null;
   selectedWeek: Date | null;
   render: () => void;
   changeWeek: (offsetWeeks: number) => Promise<void>;
@@ -512,7 +514,7 @@ export class AttendanceCalculatorView {
     gridStart: number,
     totalMinutes: number,
     gridHeight: number,
-    groupByCode: Map<string, AttendanceSubjectGroup>,
+    groupByCode: Map<string, CalcSubjectGroup>,
     now: Date,
   ): HTMLElement {
     const startMin = timeToMinutes(lesson.item.startTime);

--- a/src/modules/timetable-exporter/model/event.ts
+++ b/src/modules/timetable-exporter/model/event.ts
@@ -1,4 +1,4 @@
-import type { TimetableItem } from "../../../api/types/timetable";
+import type { ExportTimetableItem } from "./schemas";
 import { combineDateWithTime } from "../../../utils/parsing";
 
 // Calendar formats can extend this interface with features unique to that calendar format.
@@ -45,7 +45,7 @@ function hashString(value: string): string {
   return hash.toString(36);
 }
 
-function createTimetableItemUid(item: TimetableItem): string {
+function createTimetableItemUid(item: ExportTimetableItem): string {
   const fallbackId = [
     item.entityId,
     item.type,
@@ -63,11 +63,11 @@ function createTimetableItemUid(item: TimetableItem): string {
   return `timetable-${hashString(source)}@inskewl`;
 }
 
-export function fromTimetableItem(item: TimetableItem): CalendarEvent {
+export function fromTimetableItem(item: ExportTimetableItem): CalendarEvent {
   const start = combineDateWithTime(item.date, item.startTime);
   const end = combineDateWithTime(item.date, item.endTime);
 
-  const typeLabels: Record<TimetableItem["type"], string> = {
+  const typeLabels: Record<ExportTimetableItem["type"], string> = {
     LESSON: "Undervisning",
     EVENT: "Hendelse",
     ACTIVITY: "Aktivitet",

--- a/src/modules/timetable-exporter/model/schemas.ts
+++ b/src/modules/timetable-exporter/model/schemas.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { AcademicYearSchema, TermSchema } from "../../../api/types/calendar";
+import { TimetableItemSchema } from "../../../api/types/timetable";
+
+/**
+ * Feature-driven schemas: validate only the fields the exporter needs.
+ * Fields are picked from the catalog schemas in src/api/types so transforms
+ * (e.g. dd/mm/yyyy -> Date) come along.
+ */
+export const ExportTimetableItemSchema = TimetableItemSchema.pick({
+  id: true,
+  tenant: true,
+  entityId: true,
+  type: true,
+  subject: true,
+  label: true,
+  date: true,
+  startTime: true,
+  endTime: true,
+  teachers: true,
+  locations: true,
+});
+
+export const ExportTimetableSchema = z.object({
+  timetableItems: z.array(ExportTimetableItemSchema),
+});
+
+export const ExportAcademicYearSchema = AcademicYearSchema.pick({
+  currentYear: true,
+}).extend({
+  terms: z.array(TermSchema.pick({ current: true, endDate: true })),
+});
+
+export type ExportTimetableItem = z.infer<typeof ExportTimetableItemSchema>;

--- a/src/modules/timetable-exporter/timetable-exporter.ts
+++ b/src/modules/timetable-exporter/timetable-exporter.ts
@@ -1,5 +1,9 @@
 import { api } from "../../api/api";
-import type { Timetable } from "../../api/types/timetable";
+import { z } from "zod";
+import {
+  ExportAcademicYearSchema,
+  ExportTimetableSchema,
+} from "./model/schemas";
 import type { Injectable } from "../core/Injectable";
 import { dropdownAction } from "../core/injectables";
 import { VismaModule } from "../core/VismaModule";
@@ -38,7 +42,9 @@ export class TimetableExporter extends VismaModule {
   }
 
   private async loadEvents(): Promise<CalendarEvent[]> {
-    const currentAcademicYear = await api.calendar.getCurrentAcademicYear();
+    const currentAcademicYear = await api.calendar.getCurrentAcademicYear(
+      z.array(ExportAcademicYearSchema),
+    );
     const currentTerm = api.calendar.getCurrentTerm(currentAcademicYear);
 
     const weeks: Date[] = getWeekStartDates(
@@ -46,8 +52,8 @@ export class TimetableExporter extends VismaModule {
       currentTerm.endDate,
     );
 
-    const timetables: Timetable[] = await Promise.all(
-      weeks.map((week) => api.timetable.getTimetable(week)),
+    const timetables = await Promise.all(
+      weeks.map((week) => api.timetable.getTimetable(week, ExportTimetableSchema)),
     );
 
     return timetables.flatMap((t) =>


### PR DESCRIPTION
Closes #62.

## What
Endpoints no longer enforce whole-response schemas. Each module declares its own Zod schema — `.pick()`ed from the catalog in `src/api/types` — with exactly the fields it consumes, and endpoint methods take that schema as a **required** argument, returning `z.output` of it.

- `src/api/types/*` is now a **field catalog** (documentation + transforms), not an enforced contract
- New feature schemas: `timetable-exporter/model/schemas.ts`, `attendance-calculator/attendance-calculator.schemas.ts` (field lists grep-verified against actual module usage)
- `Session.getLearnerId()` validates only `{ learnerId }` — features no longer transitively depend on the full user schema
- `testAllApiSchemas()` passes full catalog schemas explicitly, keeping its drift-detection role
- Docs updated: `arkitektur.md`, `modul-eksempel.md` (pick pattern is now the canonical example), `utvikling.md`, `CLAUDE.md`

## Why
The VIS API is undocumented and unstable. Previously a change to *any* field — even ones no feature reads — broke features at runtime. Now a feature fails only when a field it actually consumes changes, and picks referencing renamed/removed catalog keys fail at **compile time**, pointing at exactly the affected features.

## Verification
- `tsc --noEmit`: clean (pre-existing dated test-file errors unchanged)
- `npm run build` + `npm run build:docs-assets`: ✓
- [x] Live: `window.testAllApiSchemas()` + smoke-test ICS export and attendance calculator (needs a browser session)